### PR TITLE
fix: Allow theme to be zero (todoist red)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export function showQuickAdd(parms: ShowParams = {}) {
     if (parms.date) {
         urlParms += '&date=' + encodeURIComponent(parms.date)
     }
-    if (parms.theme) {
+    if (parms.theme || parms.theme === 0) {
         urlParms += '&theme=' + encodeURIComponent(parms.theme)
     }
     if (parms.project_id) {


### PR DESCRIPTION
When passing `theme: 0` we would not set any theme parameter on the quick add page which in turn defaults to the user's theme. We do want to be able to force the Todoist Red theme though, this PR achieves this.

---

Related to https://github.com/Doist/twist-web/pull/4296 and the conversation in https://twist.com/a/1585/ch/190200/t/2878177/