### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup Node 12
               uses: actions/setup-node@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup Node 12
               uses: actions/setup-node@v1


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
